### PR TITLE
Fix equality comparisons with ==/!= operator on ValueObject

### DIFF
--- a/src/Backend.Fx.Ddd/ValueObject.cs
+++ b/src/Backend.Fx.Ddd/ValueObject.cs
@@ -44,6 +44,9 @@ public abstract class ValueObject : IEquatable<ValueObject>
             return hash;
         }
     }
+    public static bool operator ==(ValueObject left, ValueObject right) => Equals(left, right);
+
+    public static bool operator !=(ValueObject left, ValueObject right) => !Equals(left, right);
 }
 
 public abstract class ComparableValueObject : ValueObject, IComparable

--- a/tests/Backend.Fx.Ddd.Tests/TheValueObject.cs
+++ b/tests/Backend.Fx.Ddd.Tests/TheValueObject.cs
@@ -14,6 +14,8 @@ public class TheValueObject
     public void ObjectIsNotEqualToNull()
     {
         Assert.False(_sut1.Equals(null));
+        Assert.False(_sut1 == null);
+        Assert.True(_sut1 != null);
     }
     
     [Fact]
@@ -34,6 +36,9 @@ public class TheValueObject
     {
         Assert.Equal(_sut1, _sut1);
         Assert.True(_sut1.Equals(_sut1));
+#pragma warning disable CS1718 // Comparison made to same variable
+        Assert.True(_sut1 == _sut1);
+        Assert.False(_sut1 != _sut1);
     }
     
     [Fact]
@@ -41,6 +46,8 @@ public class TheValueObject
     {
         Assert.Equal(_sut1, _sut2);
         Assert.True(_sut1.Equals(_sut2));
+        Assert.True(_sut1 == _sut2);
+        Assert.False(_sut1 != _sut2);
     }
     
     [Fact]
@@ -48,6 +55,8 @@ public class TheValueObject
     {
         Assert.NotEqual(_sut1, _sut3);
         Assert.False(_sut1.Equals(_sut3));
+        Assert.False(_sut1 == _sut3);
+        Assert.True(_sut1 != _sut3);
     }
     
     [Fact]
@@ -55,6 +64,8 @@ public class TheValueObject
     {
         Assert.NotEqual(_sut1, _sut4);
         Assert.False(_sut1.Equals(_sut4));
+        Assert.False(_sut1 == _sut4);
+        Assert.True(_sut1 != _sut4);
     }
 
     private class Sut(string property) : ValueObject


### PR DESCRIPTION
This PR fixes an issue where comparing equality with == or != operators would only compare object references, and not internal values. By adjusting this, it allows for more intuitive use of ValueObjects.